### PR TITLE
add description property to edges

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from janusgraph_python.process.traversal import Text
 from models import *
 
 
-app = FastAPI(title="ObjectiveNet API", version="v0.1.2")
+app = FastAPI(title="ObjectiveNet API", version="v0.1.3")
 
 env_path = PathlibPath("/app/.env") if os.getenv("DOCKER_ENV") else PathlibPath(".env")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -440,6 +440,7 @@ def create_gremlin_edge(edge: EdgeBase, db=Depends(get_db_connection)) -> Gremli
     created_edge = db.V(edge.source).add_e(edge.edge_type)
     created_edge = created_edge.property("cprob", edge.cprob)
     created_edge = created_edge.property("references", parse_list(edge.references))
+    created_edge = created_edge.property("description", edge.description)
     created_edge = created_edge.to(__.V(edge.target))
     return created_edge.next()
 
@@ -492,6 +493,8 @@ def update_gremlin_edge(edge: EdgeBase, db=Depends(get_db_connection)) -> Gremli
         updated_edge = updated_edge.property("cprob", edge.cprob)
     if edge.references is not None:
         updated_edge = updated_edge.property("references", parse_list(edge.references))
+    if edge.description is not None:
+        updated_edge = updated_edge.property("description", edge.description)
     return updated_edge.next()
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -106,6 +106,7 @@ class EdgeBase(BaseModel):
     source_from_ui: int | None = None
     target_from_ui: int | None = None
     references: list[str] = []
+    description: str | None = None
 
     @field_validator("cprob")
     def convert_nan_to_none(cls, v):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "objectivenet-vue",
-  "version": "v0.1.2",
+  "version": "v0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "objectivenet-vue",
-      "version": "v0.1.2",
+      "version": "v0.1.3",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@vue-flow/background": "^1.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "objectivenet-vue",
   "private": true,
-  "version": "v0.1.2",
+  "version": "v0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
there was a field on frontend for edge description but no corresponding property in the graph database, making it impossible to save that description. Now fixed